### PR TITLE
Add PHP 8.3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 
 # Testing
 phpunit.xml
+coverage.xml
+.phpunit.cache

--- a/Tests/CoinRollerTest.php
+++ b/Tests/CoinRollerTest.php
@@ -30,7 +30,7 @@ class CoinRollerTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/DiceRollerTest.php
+++ b/Tests/DiceRollerTest.php
@@ -30,7 +30,7 @@ class DiceRollerTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Distributions/CoinDistributionTest.php
+++ b/Tests/Distributions/CoinDistributionTest.php
@@ -28,7 +28,7 @@ class CoinDistributionTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Distributions/DiceDistributionTest.php
+++ b/Tests/Distributions/DiceDistributionTest.php
@@ -28,7 +28,7 @@ class DiceDistributionTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Validators/ProbabilityValidatorTest.php
+++ b/Tests/Validators/ProbabilityValidatorTest.php
@@ -28,7 +28,7 @@ class ProbabilityValidatorTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/Tests/Validators/UnBiasedValidatorTest.php
+++ b/Tests/Validators/UnBiasedValidatorTest.php
@@ -28,7 +28,7 @@ class UnBiasedValidatorTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.3"
+        "phpunit/phpunit": "~11.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Upgrade composer packages:

- PHP: 8.3
- phpunit/phpunit: 11.4

### PHPUnit:
- Adjusted syntax from PHPUnit 6.3 and update tests for PHPUnit 11.4 compatibility